### PR TITLE
Add dynamodb resources for the Gear model (table and iam permissions)

### DIFF
--- a/caampr-backend/build.gradle
+++ b/caampr-backend/build.gradle
@@ -40,7 +40,8 @@ dependencies {
             'com.amazonaws:aws-lambda-java-events:3.7.0',
             'com.googlecode.json-simple:json-simple:1.1.1',
             'com.google.code.gson:gson:2.8.6',
-            'com.google.dagger:dagger:2.33'
+            'com.google.dagger:dagger:2.33',
+            'javax.annotation:javax.annotation-api:1.3.2'
     )
 
     annotationProcessor(

--- a/caampr-backend/cloudformation/template.yml
+++ b/caampr-backend/cloudformation/template.yml
@@ -8,6 +8,8 @@ Parameters:
     Default: ''
 
 Resources:
+
+# Lambdas
   GetGearListHandler:
     Type: 'AWS::Serverless::Function'
     Properties:
@@ -18,11 +20,14 @@ Resources:
             - !Ref DevSuffix
       Handler: com.jelistan.caampr.lambda.dagger.InvocationHandlers::handleGetGearListRequest
       Runtime: java8
-      Description: Java Lambda Function
+      Description: Fetches the gear list for a provided profile
       MemorySize: 512
-      Timeout: 300
+      Timeout: 60
       CodeUri: ../build/distributions/caampr-backend-1.0-SNAPSHOT.zip
       Role: !GetAtt LambdaRole.Arn
+      Policies: [
+        !Join ["", ["", !Ref GearDDBAccessManagedPolicy]]
+      ]
       Environment:
         Variables:
           ROLE_NAME: !Ref LambdaRole
@@ -65,3 +70,53 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: "*"
+
+# DynamoDB Resources
+  GearTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    Properties:
+      TableName: Gear-v1
+      BillingMode: "PAY_PER_REQUEST"
+      AttributeDefinitions:
+        - AttributeName: "id"
+          AttributeType: "S"
+        - AttributeName: "profileId"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "id"
+          KeyType: "HASH"
+      GlobalSecondaryIndexes:
+        - IndexName: "gear-by-profile"
+          KeySchema:
+            - AttributeName: "profileId"
+              KeyType: "HASH"
+            - AttributeName: "id"
+              KeyType: "RANGE"
+          Projection:
+            ProjectionType: "ALL"
+      Tags:
+        - Key: TableName
+          Value: Gear
+        - Key: Project
+          Value: cammpr
+
+# IAM Resources
+  GearDDBAccessManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: GearDDBAccess
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: 'Allow'
+            Action:
+              - 'dynamodb:UpdateItem'
+              - 'dynamodb:BatchWriteItem'
+              - 'dynamodb:Query'
+              - 'dynamodb:PutItem'
+              - 'dynamodb:DeleteItem'
+              - 'dynamodb:GetItem'
+            Resource:
+              - !GetAtt GearTable.Arn
+              - !Join [ '/', [ !GetAtt GearTable.Arn, 'index/*' ] ]


### PR DESCRIPTION
Issue: https://github.com/jebaney/caampr-backend/issues/8

## Notes
* Adds cfn template resources for dynamodb gear table
* Adds cfn template resources for IAM managed policy so lambda can CRUD on the table
* Updates cfn template for gear list lambda to attach the managed policy

## Testing
* `gradle clean`
* `gradle build`
* `gradle buildAWSLambdaZip`
* `./sam-helper package jbaney`
* `./sam-helper deploy jbaney`

All successful

* Log into AWS console (ensure the correct region)
  * Table now exists in dynamodb
  * managed policy exists in IAM (global)
  * managed policy is attached to the lambda