### PR TITLE
Adding logging (slf4j over log4j2) and fixing compilation issue

### DIFF
--- a/caampr-backend/build.gradle
+++ b/caampr-backend/build.gradle
@@ -26,6 +26,13 @@ repositories {
 }
 
 dependencies {
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.+'
+    // Logging - slf4j over log4j2
+    implementation 'org.apache.logging.log4j:log4j-api:2.13.0'
+    implementation 'org.apache.logging.log4j:log4j-core:2.13.0'
+    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j18-impl:2.13.0'
+    runtimeOnly 'com.amazonaws:aws-lambda-java-log4j2:1.2.0'
+
     implementation platform('com.amazonaws:aws-java-sdk-bom:1.11.969')
     implementation (
         'com.amazonaws:aws-java-sdk-dynamodb',

--- a/caampr-backend/src/main/java/com/jelistan/caampr/lambda/handler/GetGearListHandler.java
+++ b/caampr-backend/src/main/java/com/jelistan/caampr/lambda/handler/GetGearListHandler.java
@@ -10,6 +10,7 @@ import com.jelistan.caampr.lambda.adaptor.GearListRequestAdaptor;
 import com.jelistan.caampr.lambda.model.Gear;
 import com.jelistan.caampr.lambda.model.GearListRequest;
 import com.jelistan.caampr.lambda.provider.GearProvider;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.inject.Inject;
 import java.util.Collections;
@@ -18,6 +19,7 @@ import java.util.List;
 /**
  * API for handling the fetching of lists of gear
  */
+@Slf4j
 public class GetGearListHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private final GearProvider gearProvider;
@@ -32,6 +34,7 @@ public class GetGearListHandler implements RequestHandler<APIGatewayProxyRequest
     @Override
     public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, Context context)  {
         final GearListRequest gearListRequest = adaptor.convert(event);
+        log.info("Handling getGearList request [{}]", gearListRequest);
         final Gson gson = new GsonBuilder().create();
         final List<Gear> list = gearProvider.getGearList(gearListRequest);
 

--- a/caampr-backend/src/main/resources/log4j2.xml
+++ b/caampr-backend/src/main/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<Configuration status="WARN">
+    <Appenders>
+        <Lambda name="Lambda">
+            <PatternLayout>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+            </PatternLayout>
+        </Lambda>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Lambda"/>
+        </Root>
+        <Logger name="software.amazon.awssdk" level="WARN" />
+        <Logger name="software.amazon.awssdk.request" level="DEBUG" />
+    </Loggers>
+</Configuration>

--- a/caampr-backend/src/test/java/com/jelistan/caampr/lambda/handler/GetGearListHandlerTest.java
+++ b/caampr-backend/src/test/java/com/jelistan/caampr/lambda/handler/GetGearListHandlerTest.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.google.common.collect.Lists;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import com.jelistan.caampr.lambda.adaptor.GearListRequestAdaptor;
 import com.jelistan.caampr.lambda.model.Gear;
 import com.jelistan.caampr.lambda.model.GearListRequest;
 import com.jelistan.caampr.lambda.provider.GearProvider;
@@ -32,6 +33,9 @@ public class GetGearListHandlerTest {
     @Mock
     private GearProvider gearProvider;
 
+    @Mock
+    private GearListRequestAdaptor adaptor;
+
     private GetGearListHandler unit;
 
     @Before
@@ -43,7 +47,10 @@ public class GetGearListHandlerTest {
 
         when(requestEvent.getPath()).thenReturn("/users/6969/gear/");
 
-        unit = new GetGearListHandler(gearProvider);
+        when(adaptor.convert(any(APIGatewayProxyRequestEvent.class)))
+                .thenReturn(GearListRequest.builder().profileId("6969").build());
+
+        unit = new GetGearListHandler(gearProvider, adaptor);
     }
 
     @Test


### PR DESCRIPTION
## Notes
* adds the log4j2 and slf4j2 dependencies to gradle file
* adds log4j2.xml file for lambdas
* adds sample logging to the gear list handler
* fixes an issue with the get gear list handler test (failing compilation)

## Issues
*  https://github.com/jebaney/caampr-backend/issues/11

## Testing
* `gradle clean && gragle build` all succeed
* packaging and deploying succeed
* running a test payload results in a new log message in cloudwatch:
  * Note that the `to` for profileId below is due to the adapter splitting the fake path form the fake request.  This is not a problem
```
2021-03-17 22:41:45  INFO  GetGearListHandler - Handling getGearList request [GearListRequest(callerId=6969, profileId=to)]
```